### PR TITLE
Update noVNC setup for Ubuntu 24.04 and restore desktop usability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget \
   net-tools \
   locales \
+  python3 \
+  python3-numpy \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,74 +1,73 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 LABEL maintainer="Masashi Umezawa <ume@softumeya.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-## Install prerequisites and utilities
-RUN apt update && apt install -y \
+# --------------------
+# Install packages
+# --------------------
+# - software-properties-common: add-apt-repository support
+# - supervisor: process manager
+# - vim-tiny: minimal editor
+# - xvfb: virtual X server
+# - x11vnc: VNC server
+# - icewm: lightweight window manager
+# - wget: download noVNC/websockify
+# - net-tools: network utilities (netstat etc.)
+# - locales: locale support
+RUN apt-get update && apt-get install -y --no-install-recommends \
   software-properties-common \
-  python3-software-properties \
-  libssl-dev \
-  libgit2-dev \
-  libssh2-1 \
   supervisor \
   vim-tiny \
-  && rm -rf /var/lib/apt/lists/*
-
-# --------------------
-# VNC
-# --------------------
-RUN apt update && apt install -y \
   xvfb \
   x11vnc \
   icewm \
   wget \
   net-tools \
   locales \
-  bzip2 \
-  python3-numpy \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+# --------------------
+# VNC / noVNC
+# --------------------
 ENV VNC_PORT=5900 \
   NO_VNC_PORT=6901
 EXPOSE $VNC_PORT $NO_VNC_PORT
 
-### Envrionment config
 ENV VNC_PW=vncpassword \
   NO_VNC_HOME=/headless/noVNC \
-  DESKTOP_BACKGROUND_COLOR=yellow \
-  DEBIAN_FRONTEND=noninteractive
+  DESKTOP_BACKGROUND_COLOR=yellow
 
 RUN mkdir -p $NO_VNC_HOME/utils/websockify && \
-  wget -qO- https://github.com/novnc/noVNC/archive/v1.1.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME && \
-  wget -qO- https://github.com/novnc/websockify/archive/v0.10.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME/utils/websockify && \
+  wget -qO- https://github.com/novnc/noVNC/archive/v1.4.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME && \
+  wget -qO- https://github.com/novnc/websockify/archive/v0.11.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME/utils/websockify && \
   chmod +x -v $NO_VNC_HOME/utils/*.sh && \
   ln -s $NO_VNC_HOME/vnc_lite.html $NO_VNC_HOME/index.html
 
-# add self.pem file if you force ssl only access 
+# add self.pem file if you force ssl only access
 COPY ./cert/*.pem $NO_VNC_HOME/utils/websockify/
 ENV NO_VNC_CERT_FILE=self.pem
 
 # --------------------
-# Setup
+# Setup scripts
 # --------------------
 COPY ./scripts/setup-wm.sh /usr/local/bin/
 COPY ./scripts/setup-vnc.sh /usr/local/bin/
 COPY ./scripts/setup-envs-all.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/setup-*.sh
-RUN ln -s /usr/bin/python2 /usr/bin/python
 
 # --------------------
-# Locale
+# Locale / Timezone
 # --------------------
-ENV LANG=C.UTF-8
-ENV LC_ALL=C.UTF-8
-ENV TZ=Asia/Tokyo
+ENV LANG=C.UTF-8 \
+  LC_ALL=C.UTF-8 \
+  TZ=Asia/Tokyo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # --------------------
 # Workspace
 # --------------------
-
 COPY images /root/images
 
 VOLUME "/root/data"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   xvfb \
   x11vnc \
   icewm \
+  xterm \
   wget \
   net-tools \
   locales \
@@ -42,7 +43,7 @@ ENV VNC_PW=vncpassword \
 RUN mkdir -p $NO_VNC_HOME/utils/websockify && \
   wget -qO- https://github.com/novnc/noVNC/archive/v1.4.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME && \
   wget -qO- https://github.com/novnc/websockify/archive/v0.11.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME/utils/websockify && \
-  chmod +x -v $NO_VNC_HOME/utils/*.sh && \
+  (find $NO_VNC_HOME/utils -maxdepth 1 -type f -name '*.sh' -exec chmod +x -v {} \; || true) && \
   ln -s $NO_VNC_HOME/vnc_lite.html $NO_VNC_HOME/index.html
 
 # add self.pem file if you force ssl only access

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ ENV VNC_PW=vncpassword \
 RUN mkdir -p $NO_VNC_HOME/utils/websockify && \
   wget -qO- https://github.com/novnc/noVNC/archive/v1.4.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME && \
   wget -qO- https://github.com/novnc/websockify/archive/v0.11.0.tar.gz | tar xz --strip 1 -C $NO_VNC_HOME/utils/websockify && \
-  (find $NO_VNC_HOME/utils -maxdepth 1 -type f -name '*.sh' -exec chmod +x -v {} \; || true) && \
   ln -s $NO_VNC_HOME/vnc_lite.html $NO_VNC_HOME/index.html
 
 # add self.pem file if you force ssl only access

--- a/scripts/setup-vnc.sh
+++ b/scripts/setup-vnc.sh
@@ -20,10 +20,12 @@ sleep 2
 DISPLAY=:0 icewm-session 2>/dev/null &
 sleep 2
 
-# Start noVNC
-NO_VNC_CERT_FILE_PATH=$NO_VNC_HOME/utils/websockify/$NO_VNC_CERT_FILE
-if [[ -f $NO_VNC_CERT_FILE_PATH ]]; then
-  $NO_VNC_HOME/utils/launch.sh --vnc localhost:$VNC_PORT --listen $NO_VNC_PORT --ssl-only --cert $NO_VNC_CERT_FILE_PATH &> ~/no_vnc_startup.log &
+# Start noVNC (noVNC v1.4.0+: use utils/novnc_proxy instead of utils/launch.sh)
+NO_VNC_CERT_FILE_PATH="$NO_VNC_HOME/utils/websockify/$NO_VNC_CERT_FILE"
+if [[ -f "$NO_VNC_CERT_FILE_PATH" ]]; then
+  # SSL enabled
+  "$NO_VNC_HOME/utils/novnc_proxy" --vnc "localhost:$VNC_PORT" --listen "$NO_VNC_PORT" --ssl-only --cert "$NO_VNC_CERT_FILE_PATH" &> ~/no_vnc_startup.log &
 else
-  $NO_VNC_HOME/utils/launch.sh --vnc localhost:$VNC_PORT --listen $NO_VNC_PORT &> ~/no_vnc_startup.log &
+  # HTTP only
+  "$NO_VNC_HOME/utils/novnc_proxy" --vnc "localhost:$VNC_PORT" --listen "$NO_VNC_PORT" &> ~/no_vnc_startup.log &
 fi

--- a/scripts/setup-wm.sh
+++ b/scripts/setup-wm.sh
@@ -5,3 +5,11 @@ BACKGROUND_COLOR=${DESKTOP_BACKGROUND_COLOR:-'yellow'}
 mkdir -p ~/.icewm
 echo 'Theme="icedesert/default.theme"' >>  ~/.icewm/theme
 echo "DesktopBackgroundImage = \"/root/images/$DESKTOP_BACKGROUND_COLOR.jpg\"" >> $HOME/.icewm/preferences
+
+# Create a simple IceWM Programs menu with xterm if no menu is defined yet
+MENU_FILE="$HOME/.icewm/menu"
+if [[ ! -s "$MENU_FILE" ]]; then
+  cat > "$MENU_FILE" <<'EOF'
+prog "XTerm" xterm xterm
+EOF
+fi


### PR DESCRIPTION
Update the Docker image to Ubuntu 24.04 with a working noVNC setup using utils/novnc_proxy instead of the deprecated launch.sh.
Install xterm and generate a minimal IceWM Programs menu so that a terminal is available from the desktop again.
Simplify the noVNC installation step by removing the unnecessary chmod over utils/*.sh, avoiding build issues with newer noVNC layouts.